### PR TITLE
Added multi-routing capability, does not copy if a match cannot be found

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Dassort
 
-Welcome!  This is a package for copying files from one directory to another over scp.  A simple configuration allows the flexibilty of running code on files with particular extensions, and simple data sorting.
+Welcome!  This is a package for copying files from one directory to another over scp.  A simple configuration allows the flexibility of running code on files with particular extensions, and simple data sorting.
 
 ## Table of Contents
 
@@ -20,7 +20,7 @@ pip install -e .
 
 ![How to do it](/docs/dassort_example.gif)
 
-`dassort` is meant to be run in a directory that contains a `dassort.yaml` configuration file. 
+`dassort` is meant to be run in a directory that contains a `dassort.yaml` configuration file.
 
 UNDER CONSTRUCTION
 

--- a/examples/dassort.yaml
+++ b/examples/dassort.yaml
@@ -3,8 +3,16 @@ dassort:
     keys: ['SubjectName','subject_name']
     map:  ['subject']
     default: ['unsorted']
+  # build a path to copy to, json keys are mapped to the variable in map, ${root} is the destination folder, ${sub_folder}, for the originating sub-folder
   path: ${root}/${subject}/
   command:
+    # run commands if we encounter either files or directories with specific files
     exts: ['depth.dat','.tar.gz']
     run: ['ssh ${user}@${cmd_host} "kinect_extract_it.sh -i ${path} -e o2 -c --matlab-path /n/app/matlab/2016b/bin/"']
   destination: '/n/groups/datta/Jeff/workspace/photometry_nac_d1d2'
+  # parameters for copying to a remote destination (copy_protocol nocopy will lead to deletion)
+  remote:
+    user: MYLOGIN
+    host: HOST
+    copy_protocol: scp
+    cmd_host: HOST_RUN_CMD

--- a/examples/router.yaml
+++ b/examples/router.yaml
@@ -1,0 +1,21 @@
+# this file specifies which config to "route" to if a condition is met, any option can be a list
+router:
+  # which keys in the json file to match
+  key: 
+    - SessionName
+    - SubjectName
+    - SubjectName
+  # regex expressions to match
+  filter:
+    - sessiontype1|sessiontype2
+    - mouse1|mouse2|mouse3
+    - ofa
+  lowercase: True
+  # must the match be exact?
+  exact: False 
+  # ignore case?
+  invert: False
+  files:
+    - config1.yaml # where to route if regex 1 matches
+    - config2.yaml # where to route if regex 2 matches
+    - config3.yaml # where to route if regex 3 matches

--- a/util.py
+++ b/util.py
@@ -1,10 +1,10 @@
 import json
 import yaml
 import re
-import itertools
 import logging
 import os
 import time
+from itertools import cycle
 
 
 def find_key(key, var):
@@ -87,6 +87,10 @@ def read_config(file, destination=None, user=None, host=None, cmd_host=None, cop
     elif 'router' in base_yaml.keys():
         tree_yaml = base_yaml['router']
         router_config = merge_dicts(router_config, tree_yaml)
+        # all router items should be iterables
+        for k, v in router_config.items():
+            if type(v) is not list:
+                router_config[k] = [v]
         base_config = None
         remote_config = None
 
@@ -180,41 +184,67 @@ def get_listing_manifest(proc):
 def parse_router(router, dirs, files):
 
     router_status = []
-    if router['exact']:
-        router_re = r'\b{}\b'.format(router['filter'])
-    else:
-        router_re = r'{}'.format(router['filter'])
+    router_re = []
+    for filter, exact in zip(router['filter'], cycle(router['exact'])):
+        if exact:
+            router_re.append(r'\b{}\b'.format(filter))
+        else:
+            router_re.append(r'{}'.format(filter))
 
+    # first search directories
     for jsons in dirs:
         js_data = []
         for js in jsons:
             with open(js, 'r') as j:
                 js_data.append(json.load(j))
-        if router['lowercase']:
-            hits = [re.search(router_re, j[router['key']].lower())
-                    is not None for j in js_data]
-        else:
-            hits = [re.search(router_re, j[router['key']])
-                    is not None for j in js_data]
-        router_status.append(any(hits))
+        dir_status = []
+        for filter, key, lowercase, invert in zip(router_re,
+                                                  cycle(router['key']),
+                                                  cycle(router['lowercase']),
+                                                  cycle(router['invert'])):
+            if lowercase:
+                hits = [re.search(filter, j[key], re.IGNORECASE) is not None for j in js_data]
+            else:
+                hits = [re.search(filter, j[key]) is not None for j in js_data]
 
-    js_data = []
+            if invert:
+                dir_status.append(not any(hits))
+            else:
+                dir_status.append(any(hits))
+
+        try:
+            router_status.append(dir_status.index(True))
+        except ValueError:
+            router_status.append(None)
+
+    # then search files
     for js in files:
+
         with open(js, 'r') as j:
-            js_data.append(json.load(j))
+            js_data = json.load(j)
 
-    if router['lowercase']:
-        hits = [re.search(router_re, j[router['key']].lower())
-                is not None for j in js_data]
-    else:
-        hits = [re.search(router_re, j[router['key']])
-                is not None for j in js_data]
+        if js_data is None:
+            continue
 
-    if router['invert']:
-        router_status = [not status for status in router_status]
+        file_status = []
+        for filter, key, lowercase, invert in zip(router_re,
+                                                  cycle(router['key']),
+                                                  cycle(router['lowercase']),
+                                                  cycle(router['invert'])):
 
-    for hit in hits:
-        router_status.append(hit)
+            if lowercase:
+                hit = re.search(filter, js_data[key].lower())
+            else:
+                hit = re.search(filter, js_data[key])
+
+            if invert:
+                hit = not hit
+
+            file_status.append(hit)
+        try:
+            router_status.append(file_status.index(True))
+        except ValueError:
+            router_status.append(None)
 
     return router_status
 
@@ -270,7 +300,7 @@ def proc_loop(listing, base_dict, dry_run, delete, remote_options):
         for m, d in zip(use_dict['map'], use_dict['default']):
             use_dict['path']['re'][m] = d
 
-        for k, v in zip(use_dict['keys'], itertools.cycle(use_dict['map'])):
+        for k, v in zip(use_dict['keys'], cycle(use_dict['map'])):
             generators = find_key(k, dict_json)
             use_dict['path']['re'][v] = next(
                 generators, use_dict['path']['re'][v])
@@ -336,7 +366,7 @@ def proc_loop(listing, base_dict, dry_run, delete, remote_options):
             'path': ''
         }
 
-        for ext, cmd in zip(use_dict['command']['exts'], itertools.cycle(use_dict['command']['run'])):
+        for ext, cmd in zip(use_dict['command']['exts'], cycle(use_dict['command']['run'])):
             triggers = [f for f in listing_manifest if f.endswith(ext)]
             if triggers and not dry_run and not delete:
                 raise NameError(

--- a/util.py
+++ b/util.py
@@ -233,7 +233,7 @@ def parse_router(router, dirs, files):
                                                   cycle(router['invert'])):
 
             if lowercase:
-                hit = re.search(filter, js_data[key].lower())
+                hit = re.search(filter, js_data[key], re.IGNORECASE)
             else:
                 hit = re.search(filter, js_data[key])
 


### PR DESCRIPTION
For a router file, any option can be specified as a list, otherwise the value is "filled" in via cycling. This allows for arbitrary config files, subject keys, session names, etc. Also, this no copying is performed if a match cannot be found.